### PR TITLE
Dependencygraph fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env/
 deploy-locally.sh
+/.idea/

--- a/.helm/templates/statefulset.yaml
+++ b/.helm/templates/statefulset.yaml
@@ -78,6 +78,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+
+        # Specify how many replicas we have
+        - name: REPLICAS
+          value: {{ .Values.statefulset.replicas | quote }}
 ---
 apiVersion: v1
 kind: Service

--- a/.helm/values.yaml
+++ b/.helm/values.yaml
@@ -6,7 +6,7 @@ app: {
 }
 statefulset: {
   name: omnicross,
-  replicas: 3
+  replicas: 4
 }
 
 

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -3,6 +3,7 @@ import random
 from time import sleep
 import requests
 from flask import Flask, jsonify
+from wait_for_finder import find_wait_for
 
 app = Flask(__name__)
 
@@ -47,9 +48,10 @@ def read_from_log(from_idx):
 def read_log(from_idx):
     log_data = read_from_log(from_idx)
     print(log_data)
-    print(log_data["log_data"][0])
+    print(f"Car {PID} waits for car {find_wait_for(PID, log_data)}.")
     # TODO: convert log to dependency graph and return depency graph instead of log
     # To see return data format check root/README.md or rsm/README.md
+    log_data["wait_for"] = find_wait_for(PID, log_data)
     return jsonify(log_data)
 
 if __name__ == "__main__":

--- a/app/src/wait_for_finder.py
+++ b/app/src/wait_for_finder.py
@@ -1,0 +1,170 @@
+
+# this function is to convert the form_to data to the index
+# for example, (1,2) -> 0
+def data2index(frm, to):
+    index_dict = {
+        (1, 2): 0,
+        (1, 3): 1,
+        (1, 4): 2,
+        (2, 1): 3,
+        (2, 3): 4,
+        (2, 4): 5,
+        (3, 1): 6,
+        (3, 2): 7,
+        (3, 4): 8,
+        (4, 1): 9,
+        (4, 2): 10,
+        (4, 3): 11,
+    }
+    return index_dict[(frm, to)]
+
+
+def conflict_rule_setup():
+    conflict_matrix = [[False for _ in range(12)] for _ in range(12)]
+    # from1 conflicts
+    conflict_matrix[data2index(1, 2)][data2index(2, 3)] = True
+    conflict_matrix[data2index(1, 2)][data2index(2, 4)] = True
+    conflict_matrix[data2index(1, 2)][data2index(2, 3)] = True
+    conflict_matrix[data2index(1, 2)][data2index(3, 1)] = True
+    conflict_matrix[data2index(1, 2)][data2index(3, 2)] = True
+    conflict_matrix[data2index(1, 2)][data2index(4, 1)] = True
+    conflict_matrix[data2index(1, 2)][data2index(4, 2)] = True
+    conflict_matrix[data2index(1, 3)][data2index(2, 3)] = True
+    conflict_matrix[data2index(1, 3)][data2index(2, 4)] = True
+    conflict_matrix[data2index(1, 3)][data2index(3, 4)] = True
+    conflict_matrix[data2index(1, 3)][data2index(4, 1)] = True
+    conflict_matrix[data2index(1, 3)][data2index(4, 2)] = True
+    conflict_matrix[data2index(1, 3)][data2index(4, 3)] = True
+    conflict_matrix[data2index(1, 4)][data2index(2, 4)] = True
+    conflict_matrix[data2index(1, 4)][data2index(3, 4)] = True
+    # from2 conflicts
+    conflict_matrix[data2index(2, 3)][data2index(3, 4)] = True
+    conflict_matrix[data2index(2, 3)][data2index(3, 1)] = True
+    conflict_matrix[data2index(2, 3)][data2index(3, 4)] = True
+    conflict_matrix[data2index(2, 3)][data2index(4, 2)] = True
+    conflict_matrix[data2index(2, 3)][data2index(4, 3)] = True
+    conflict_matrix[data2index(2, 3)][data2index(1, 2)] = True
+    conflict_matrix[data2index(2, 3)][data2index(1, 3)] = True
+    conflict_matrix[data2index(2, 4)][data2index(3, 4)] = True
+    conflict_matrix[data2index(2, 4)][data2index(3, 1)] = True
+    conflict_matrix[data2index(2, 4)][data2index(4, 1)] = True
+    conflict_matrix[data2index(2, 4)][data2index(1, 2)] = True
+    conflict_matrix[data2index(2, 4)][data2index(1, 3)] = True
+    conflict_matrix[data2index(2, 4)][data2index(1, 4)] = True
+    conflict_matrix[data2index(2, 1)][data2index(3, 1)] = True
+    conflict_matrix[data2index(2, 1)][data2index(4, 1)] = True
+    # from3 conflicts
+    conflict_matrix[data2index(3, 4)][data2index(4, 1)] = True
+    conflict_matrix[data2index(3, 4)][data2index(4, 2)] = True
+    conflict_matrix[data2index(3, 4)][data2index(4, 1)] = True
+    conflict_matrix[data2index(3, 4)][data2index(1, 3)] = True
+    conflict_matrix[data2index(3, 4)][data2index(1, 4)] = True
+    conflict_matrix[data2index(3, 4)][data2index(2, 3)] = True
+    conflict_matrix[data2index(3, 4)][data2index(2, 4)] = True
+    conflict_matrix[data2index(3, 1)][data2index(4, 1)] = True
+    conflict_matrix[data2index(3, 1)][data2index(4, 2)] = True
+    conflict_matrix[data2index(3, 1)][data2index(1, 2)] = True
+    conflict_matrix[data2index(3, 1)][data2index(2, 3)] = True
+    conflict_matrix[data2index(3, 1)][data2index(2, 4)] = True
+    conflict_matrix[data2index(3, 1)][data2index(2, 1)] = True
+    conflict_matrix[data2index(3, 2)][data2index(4, 2)] = True
+    conflict_matrix[data2index(3, 2)][data2index(1, 2)] = True
+    # from4 conflicts
+    conflict_matrix[data2index(4, 1)][data2index(1, 2)] = True
+    conflict_matrix[data2index(4, 1)][data2index(1, 3)] = True
+    conflict_matrix[data2index(4, 1)][data2index(1, 2)] = True
+    conflict_matrix[data2index(4, 1)][data2index(2, 4)] = True
+    conflict_matrix[data2index(4, 1)][data2index(2, 1)] = True
+    conflict_matrix[data2index(4, 1)][data2index(3, 4)] = True
+    conflict_matrix[data2index(4, 1)][data2index(3, 1)] = True
+    conflict_matrix[data2index(4, 2)][data2index(1, 2)] = True
+    conflict_matrix[data2index(4, 2)][data2index(1, 3)] = True
+    conflict_matrix[data2index(4, 2)][data2index(2, 3)] = True
+    conflict_matrix[data2index(4, 2)][data2index(3, 4)] = True
+    conflict_matrix[data2index(4, 2)][data2index(3, 1)] = True
+    conflict_matrix[data2index(4, 2)][data2index(3, 2)] = True
+    conflict_matrix[data2index(4, 3)][data2index(1, 3)] = True
+    conflict_matrix[data2index(4, 3)][data2index(2, 3)] = True
+    return conflict_matrix
+
+# refer to readme for type of log
+def extract_data_from_log(log):
+    return [item['data'] for item in log['log_data']]
+
+# Find which car to wait for, return car id. If could not find current car in the log, return -1
+# If no car to wait for, return 0
+def find_wait_for(car_id, log, conflict_matrix=conflict_rule_setup()):
+    found_flg = False
+    frm_to = (0, 0)
+    wait_for = 0
+    data = extract_data_from_log(log)
+    for d in data:
+        if d["car_id"] == car_id:
+            found_flg = True
+            frm_to = (d["from"], d["to"])
+            break
+    if not found_flg:
+        return -1
+    for d in data:
+        if d["car_id"] != car_id and conflict_matrix[data2index(frm_to[0], frm_to[1])][data2index(d["from"], d["to"])]:
+            wait_for = d["car_id"]
+        elif d["car_id"] == car_id:
+            break
+    return wait_for
+
+# Can be used for testing
+# if __name__ == '__main__':
+#     log = {
+#         "decided_idx": 3,
+#         "node_id": 3,
+#         "log_data": [
+#             {
+#                 "data": {
+#                     "car_id": 4,
+#                     "from": 4,
+#                     "to": 1
+#                 },
+#                 "id": [
+#                     3,
+#                     "02cbb44d-874f-4f38-98e5-841638dbdc7d"
+#                 ]
+#             },
+#             {
+#                 "data": {
+#                     "car_id": 3,
+#                     "from": 3,
+#                     "to": 4
+#                 },
+#                 "id": [
+#                     3,
+#                     "02cbb44d-874f-4f38-98e5-841638dbdc7d"
+#                 ]
+#             },
+#             {
+#                 "data": {
+#                     "car_id": 2,
+#                     "from": 2,
+#                     "to": 3
+#                 },
+#                 "id": [
+#                     2,
+#                     "46c46125-a116-40b8-8964-c3e21fbbe99f"
+#                 ]
+#             },
+#             {
+#                 "data": {
+#                     "car_id": 1,
+#                     "from": 1,
+#                     "to": 2
+#                 },
+#                 "id": [
+#                     1,
+#                     "448568f8-9972-41aa-a6c7-e09c8009572a"
+#                 ]
+#             }
+#         ],
+#     }
+#     print(find_wait_for(1, log))
+#     print(find_wait_for(2, log))
+#     print(find_wait_for(3, log))
+#     print(find_wait_for(4, log))

--- a/app/src/wait_for_finder.py
+++ b/app/src/wait_for_finder.py
@@ -97,7 +97,7 @@ def find_wait_for(car_id, log, conflict_matrix=conflict_rule_setup()):
     car_id = int(car_id)
     found_flg = False
     frm_to = (0, 0)
-    wait_for = 0
+    wait_for = []
     data = extract_data_from_log(log)
     for d in data:
         if d["car_id"] == car_id:
@@ -106,66 +106,67 @@ def find_wait_for(car_id, log, conflict_matrix=conflict_rule_setup()):
             break
     if not found_flg:
         return -1
+    start_look_flg = False
     for d in data:
-        if d["car_id"] != car_id and conflict_matrix[data2index(frm_to[0], frm_to[1])][data2index(d["from"], d["to"])]:
-            wait_for = d["car_id"]
+        if start_look_flg and d["car_id"] != car_id and conflict_matrix[data2index(frm_to[0], frm_to[1])][data2index(d["from"], d["to"])]:
+            wait_for.append(d["car_id"])
         elif d["car_id"] == car_id:
-            break
+            start_look_flg = True
     return wait_for
 
-# # Can be used for testing
-# if __name__ == '__main__':
-#     log = {
-#         "decided_idx": 4,
-#         "log_data": [
-#             {
-#                 "data": {
-#                     "car_id": 3,
-#                     "from": 3,
-#                     "to": 2
-#                 },
-#                 "id": [
-#                     3,
-#                     "043bc4d7-2810-4098-82b5-fc85ac0252be"
-#                 ]
-#             },
-#             {
-#                 "data": {
-#                     "car_id": 1,
-#                     "from": 1,
-#                     "to": 2
-#                 },
-#                 "id": [
-#                     1,
-#                     "c93c9d74-586c-47bb-a91c-d18168dc4420"
-#                 ]
-#             },
-#             {
-#                 "data": {
-#                     "car_id": 2,
-#                     "from": 2,
-#                     "to": 1
-#                 },
-#                 "id": [
-#                     2,
-#                     "20a249d8-675e-48e1-9374-e2682ed07f35"
-#                 ]
-#             },
-#             {
-#                 "data": {
-#                     "car_id": 4,
-#                     "from": 4,
-#                     "to": 1
-#                 },
-#                 "id": [
-#                     4,
-#                     "011e673c-ea61-4a55-9f3d-7a759be22029"
-#                 ]
-#             }
-#         ],
-#         "node_id": 4
-#     }
-#     print("Car 1 waits for car", find_wait_for(1, log))
-#     print("Car 2 waits for car", find_wait_for(2, log))
-#     print("Car 3 waits for car", find_wait_for(3, log))
-#     print("Car 4 waits for car", find_wait_for(4, log))
+# Can be used for testing
+if __name__ == '__main__':
+    log = {
+        "decided_idx": 4,
+        "log_data": [
+            {
+                "data": {
+                    "car_id": 3,
+                    "from": 3,
+                    "to": 2
+                },
+                "id": [
+                    3,
+                    "043bc4d7-2810-4098-82b5-fc85ac0252be"
+                ]
+            },
+            {
+                "data": {
+                    "car_id": 1,
+                    "from": 1,
+                    "to": 2
+                },
+                "id": [
+                    1,
+                    "c93c9d74-586c-47bb-a91c-d18168dc4420"
+                ]
+            },
+            {
+                "data": {
+                    "car_id": 2,
+                    "from": 2,
+                    "to": 1
+                },
+                "id": [
+                    2,
+                    "20a249d8-675e-48e1-9374-e2682ed07f35"
+                ]
+            },
+            {
+                "data": {
+                    "car_id": 4,
+                    "from": 4,
+                    "to": 1
+                },
+                "id": [
+                    4,
+                    "011e673c-ea61-4a55-9f3d-7a759be22029"
+                ]
+            }
+        ],
+        "node_id": 4
+    }
+    print("Car 1 waits for car", find_wait_for(1, log))
+    print("Car 2 waits for car", find_wait_for(2, log))
+    print("Car 3 waits for car", find_wait_for(3, log))
+    print("Car 4 waits for car", find_wait_for(4, log))

--- a/app/src/wait_for_finder.py
+++ b/app/src/wait_for_finder.py
@@ -94,6 +94,9 @@ def extract_data_from_log(log):
 # Find which car to wait for, return car id. If could not find current car in the log, return -1
 # If no car to wait for, return 0
 def find_wait_for(car_id, log, conflict_matrix=conflict_rule_setup()):
+    car_id = int(car_id)
+    print(car_id)
+    print(log)
     found_flg = False
     frm_to = (0, 0)
     wait_for = 0

--- a/app/src/wait_for_finder.py
+++ b/app/src/wait_for_finder.py
@@ -95,8 +95,6 @@ def extract_data_from_log(log):
 # If no car to wait for, return 0
 def find_wait_for(car_id, log, conflict_matrix=conflict_rule_setup()):
     car_id = int(car_id)
-    print(car_id)
-    print(log)
     found_flg = False
     frm_to = (0, 0)
     wait_for = 0
@@ -115,43 +113,20 @@ def find_wait_for(car_id, log, conflict_matrix=conflict_rule_setup()):
             break
     return wait_for
 
-# Can be used for testing
+# # Can be used for testing
 # if __name__ == '__main__':
 #     log = {
-#         "decided_idx": 3,
-#         "node_id": 3,
+#         "decided_idx": 4,
 #         "log_data": [
-#             {
-#                 "data": {
-#                     "car_id": 4,
-#                     "from": 4,
-#                     "to": 1
-#                 },
-#                 "id": [
-#                     3,
-#                     "02cbb44d-874f-4f38-98e5-841638dbdc7d"
-#                 ]
-#             },
 #             {
 #                 "data": {
 #                     "car_id": 3,
 #                     "from": 3,
-#                     "to": 4
+#                     "to": 2
 #                 },
 #                 "id": [
 #                     3,
-#                     "02cbb44d-874f-4f38-98e5-841638dbdc7d"
-#                 ]
-#             },
-#             {
-#                 "data": {
-#                     "car_id": 2,
-#                     "from": 2,
-#                     "to": 3
-#                 },
-#                 "id": [
-#                     2,
-#                     "46c46125-a116-40b8-8964-c3e21fbbe99f"
+#                     "043bc4d7-2810-4098-82b5-fc85ac0252be"
 #                 ]
 #             },
 #             {
@@ -162,12 +137,35 @@ def find_wait_for(car_id, log, conflict_matrix=conflict_rule_setup()):
 #                 },
 #                 "id": [
 #                     1,
-#                     "448568f8-9972-41aa-a6c7-e09c8009572a"
+#                     "c93c9d74-586c-47bb-a91c-d18168dc4420"
+#                 ]
+#             },
+#             {
+#                 "data": {
+#                     "car_id": 2,
+#                     "from": 2,
+#                     "to": 1
+#                 },
+#                 "id": [
+#                     2,
+#                     "20a249d8-675e-48e1-9374-e2682ed07f35"
+#                 ]
+#             },
+#             {
+#                 "data": {
+#                     "car_id": 4,
+#                     "from": 4,
+#                     "to": 1
+#                 },
+#                 "id": [
+#                     4,
+#                     "011e673c-ea61-4a55-9f3d-7a759be22029"
 #                 ]
 #             }
 #         ],
+#         "node_id": 4
 #     }
-#     print(find_wait_for(1, log))
-#     print(find_wait_for(2, log))
-#     print(find_wait_for(3, log))
-#     print(find_wait_for(4, log))
+#     print("Car 1 waits for car", find_wait_for(1, log))
+#     print("Car 2 waits for car", find_wait_for(2, log))
+#     print("Car 3 waits for car", find_wait_for(3, log))
+#     print("Car 4 waits for car", find_wait_for(4, log))

--- a/app/src/wait_for_finder.py
+++ b/app/src/wait_for_finder.py
@@ -87,7 +87,7 @@ def conflict_rule_setup():
     conflict_matrix[data2index(4, 3)][data2index(2, 3)] = True
     return conflict_matrix
 
-# refer to readme for type of log
+# To see log data format check root/README.md or rsm/README.md
 def extract_data_from_log(log):
     return [item['data'] for item in log['log_data']]
 


### PR DESCRIPTION
> This PR fixed https://github.com/TimXLHan/omnicross/issues/2

I found it will make a dead lock if we simply out all the cars that need to be waited for, but dead lock resolution is another big problem. I turned to a simpler solution that make sure all the cars will have different priorities to deal with the dead lock. But we can further turn to some fashion deadlock resolution algorithm if we want, cause luckly we are currently working this kind of thing. I changed the code, and the output. The `wati_for` in the result changed to a list as well.
![image](https://github.com/TimXLHan/omnicross/assets/113171246/9e4f9f96-b13a-4ed5-a959-10b9ab7751c8)
